### PR TITLE
pyacoustid crashes when artist and title are missing

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -203,13 +203,18 @@ def parse_lookup_result(data):
         recording = result['recordings'][0]
 
         # Get the artist if available.
-        if recording['artists']:
+        if ('artists' in recording) and recording['artists']:
             artist = recording['artists'][0]
             artist_name = artist['name']
         else:
             artist_name = None
 
-        yield score, recording['id'], recording['title'], artist_name
+        if 'title' in recording:
+                title = recording['title']
+        else:
+                title = None
+
+        yield score, recording['id'], title, artist_name
 
 def match(apikey, path, meta=DEFAULT_META, parse=True):
     """Look up the metadata for an audio file. If ``parse`` is true,


### PR DESCRIPTION
pyacoustid crashes whenever it tries to return 07a22ad2-2709-4bcb-9951-49687d099867. I suspect this is because it has been removed from MusicBrainz.

Traceback (most recent call last):
File "id.py", line 11, in 
for i in acoustid.match(apikey, path):
File "/src/pyacoustid/acoustid.py", line 206, in parse_lookup_result
if recording['artists']:
KeyError: 'artists'

The attached commit checks for missing information and returns None when it is unavailable, much like the existing code.
