### PR TITLE
Add fpcalc.py

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -181,14 +181,14 @@ def _api_request(url, params):
     except ValueError:
         raise WebServiceError('response is not valid JSON')
 
-def fingerprint(samplerate, channels, pcmiter):
+def fingerprint(samplerate, channels, pcmiter, maxlength=MAX_AUDIO_LENGTH):
     """Fingerprint audio data given its sample rate and number of
     channels.  pcmiter should be an iterable containing blocks of PCM
     data as byte strings. Raises a FingerprintGenerationError if
     anything goes wrong.
     """
     # Maximum number of samples to decode.
-    endposition = samplerate * MAX_AUDIO_LENGTH
+    endposition = samplerate * channels * maxlength
 
     try:
         fper = chromaprint.Fingerprinter()
@@ -246,20 +246,20 @@ def parse_lookup_result(data):
 
             yield score, recording['id'], recording.get('title'), artist_name
 
-def _fingerprint_file_audioread(path):
+def _fingerprint_file_audioread(path, maxlength):
     """Fingerprint a file by using audioread and chromaprint."""
     try:
         with audioread.audio_open(path) as f:
             duration = f.duration
-            fp = fingerprint(f.samplerate, f.channels, iter(f))
+            fp = fingerprint(f.samplerate, f.channels, iter(f), maxlength)
     except audioread.DecodeError:
         raise FingerprintGenerationError("audio could not be decoded")
     return duration, fp
 
-def _fingerprint_file_fpcalc(path):
+def _fingerprint_file_fpcalc(path, maxlength):
     """Fingerprint a file by calling the fpcalc application."""
     fpcalc = os.environ.get(FPCALC_ENVVAR, FPCALC_COMMAND)
-    command = [fpcalc, "-length", str(MAX_AUDIO_LENGTH), path]
+    command = [fpcalc, "-length", str(maxlength), path]
     try:
         proc = subprocess.Popen(command, stdout=subprocess.PIPE)
         output, _ = proc.communicate()
@@ -292,16 +292,16 @@ def _fingerprint_file_fpcalc(path):
         raise FingerprintGenerationError("missing fpcalc output")
     return duration, fp
 
-def fingerprint_file(path):
+def fingerprint_file(path, maxlength=MAX_AUDIO_LENGTH):
     """Fingerprint a file either using the Chromaprint dynamic library
     or the fpcalc command-line tool, whichever is available. Returns the
     duration and the fingerprint.
     """
     path = os.path.abspath(os.path.expanduser(path))
     if have_audioread and have_chromaprint:
-        return _fingerprint_file_audioread(path)
+        return _fingerprint_file_audioread(path, maxlength)
     else:
-        return _fingerprint_file_fpcalc(path)
+        return _fingerprint_file_fpcalc(path, maxlength)
 
 def match(apikey, path, meta=DEFAULT_META, parse=True):
     """Look up the metadata for an audio file. If ``parse`` is true,

--- a/fpcalc.py
+++ b/fpcalc.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# This file is part of pyacoustid.
+# Copyright 2012, Lukas Lalinsky.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Simple script for calculating audio fingerprints, using the same
+arguments/output as the fpcalc utility from Chromaprint."""
+
+import sys
+import argparse
+import acoustid
+import chromaprint
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-length', metavar='SECS', type=int, default=120,
+                        help='length of the audio data used for fingerprint '
+                             'calculation (default 120)')
+    parser.add_argument('-raw', action='store_true',
+                        help='output the raw uncompressed fingerprint')
+    parser.add_argument('paths', metavar='FILE', nargs='+',
+                        help='audio file to be fingerprinted')
+
+    args = parser.parse_args()
+    del sys.argv[1:] # to make gst not try to parse the args
+
+    first = True
+    for i, path in enumerate(args.paths):
+        try:
+            duration, fp = acoustid.fingerprint_file(path, args.length)
+        except Exception:
+            print >>sys.stderr, "ERROR: unable to calculate fingerprint " \
+                                "for file %s, skipping" % path
+            continue
+        if args.raw:
+            raw_fp = chromaprint.decode_fingerprint(fp)[0]
+            fp = ','.join(map(str, raw_fp))
+        if not first:
+            print
+        first = False
+        print 'FILE=%s' % path
+        print 'DURATION=%d' % duration
+        print 'FINGERPRINT=%s' % fp
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
I'm not sure if you want something like this in pyacoustid, but I wasn't sure where to add it. It should probably not be installed with setup.py, but I wanted to have it somewhere available for package maintainers.

My main motivation for writing the script was that Fedora can't have the original fpcalc in the main repository, because it depends on FFmpeg and instead of reinventing what you have done with audioread, it was much easier to just write a Python script with the same inteface as fpcalc that uses your packages. Having a script like this would allow MusicBrainz Picard users to get audio fingerprinting support by default in Linux distros that don't want to deal with FFmpeg.
