### PR TITLE
Explicit the UTF-8 encoding also when installing using Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,10 @@ from setuptools import setup
 
 def _read(fn):
     path = os.path.join(os.path.dirname(__file__), fn)
-    data = open(path).read()
     if sys.version_info[0] < 3:
-        data = data.decode('utf8')
+        data = open(path).read().decode('utf8')
+    else:
+        data = open(path, encoding='utf8').read()
     # Special case some Unicode characters; PyPI seems to only like ASCII.
     data = data.replace(u'\xe1', u'a')
     data = data.replace(u'\u0161', u's')


### PR DESCRIPTION
If the locale isn't UTF-8, or for some reason Python doesn't pick up on
it, it will try to decode using ASCII, which will of course cause
mayhem, crash and despair.

This patch will be shipped with the Debian package 1.1.0-1
