### PR TITLE
Add support for bytearray in chromaprint

### DIFF
--- a/chromaprint.py
+++ b/chromaprint.py
@@ -115,8 +115,10 @@ class Fingerprinter(object):
         """
         if isinstance(data, BUFFER_TYPES):
             data = str(data)
+        elif isinstance(data, bytearray):
+            data = bytes(data)
         elif not isinstance(data, bytes):
-            raise TypeError('data must be bytes, buffer, or memoryview')
+            raise TypeError('data must be bytes, bytearray, buffer, or memoryview, not ' + str(type(data)))
         _check(_libchromaprint.chromaprint_feed(
             self._ctx, data, len(data) // 2
         ))


### PR DESCRIPTION
As noted in my comments on https://github.com/beetbox/beets/issues/1958, Beets seems to want to send bytearrays into Chromaprint, which currently wants only bytes. I have no idea how to fix it on Beets's end, so here's a PR that does the conversion.

When I just pass bytearrays on through, some other type-checking code complains about it being the wrong type, so I opted for the (possibly inefficient) conversion instead.