### PR TITLE
Fix flake8 issues

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -39,8 +39,8 @@ from io import BytesIO
 
 API_BASE_URL = 'http://api.acoustid.org/v2/'
 DEFAULT_META = 'recordings'
-REQUEST_INTERVAL = 0.33 # 3 requests/second.
-MAX_AUDIO_LENGTH = 120 # Seconds.
+REQUEST_INTERVAL = 0.33  # 3 requests/second.
+MAX_AUDIO_LENGTH = 120  # Seconds.
 FPCALC_COMMAND = 'fpcalc'
 FPCALC_ENVVAR = 'FPCALC'
 
@@ -137,7 +137,7 @@ class CompressedHTTPAdapter(requests.adapters.HTTPAdapter):
 
 # Utilities.
 
-class _rate_limit(object):
+class _rate_limit(object):  # noqa: N801
     """A decorator that limits the rate at which the function may be
     called.  The rate is controlled by the REQUEST_INTERVAL module-level
     constant; set the value to zero to disable rate limiting. The
@@ -201,10 +201,10 @@ def fingerprint(samplerate, channels, pcmiter, maxlength=MAX_AUDIO_LENGTH):
         fper = chromaprint.Fingerprinter()
         fper.start(samplerate, channels)
 
-        position = 0 # Samples of audio fed to the fingerprinter.
+        position = 0  # Samples of audio fed to the fingerprinter.
         for block in pcmiter:
             fper.feed(block)
-            position += len(block) // 2 # 2 bytes/sample.
+            position += len(block) // 2  # 2 bytes/sample.
             if position >= endposition:
                 break
 

--- a/chromaprint.py
+++ b/chromaprint.py
@@ -11,9 +11,9 @@ import ctypes
 if sys.version_info[0] >= 3:
     BUFFER_TYPES = (memoryview, bytearray,)
 elif sys.version_info[1] >= 7:
-    BUFFER_TYPES = (buffer, memoryview, bytearray,)
+    BUFFER_TYPES = (buffer, memoryview, bytearray,)  # noqa: F821
 else:
-    BUFFER_TYPES = (buffer, bytearray,)
+    BUFFER_TYPES = (buffer, bytearray,)  # noqa: F821
 
 
 # Find the base library and declare prototypes.

--- a/fpcalc.py
+++ b/fpcalc.py
@@ -21,10 +21,12 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import sys
 import argparse
+import sys
+
 import acoustid
 import chromaprint
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -37,7 +39,8 @@ def main():
                         help='audio file to be fingerprinted')
 
     args = parser.parse_args()
-    del sys.argv[1:] # to make gst not try to parse the args
+    # make gst not try to parse the args
+    del sys.argv[1:]
 
     first = True
     for i, path in enumerate(args.paths):
@@ -56,6 +59,7 @@ def main():
         print('FILE=%s' % path)
         print('DURATION=%d' % duration)
         print('FINGERPRINT=%s' % fp.decode('utf8'))
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,8 @@ def _read(fn):
 
 setup(name='pyacoustid',
       version='1.1.5',
-      description=
-        'bindings for Chromaprint acoustic fingerprinting and the '
-        'Acoustid API',
+      description=('bindings for Chromaprint acoustic fingerprinting and the '
+                   'Acoustid API'),
       author='Adrian Sampson',
       author_email='adrian@radbox.org',
       url='https://github.com/sampsyo/pyacoustid',
@@ -42,7 +41,7 @@ setup(name='pyacoustid',
       platforms='ALL',
       long_description=_read('README.rst'),
 
-      install_requires = ['audioread', 'requests'],
+      install_requires=['audioread', 'requests'],
 
       py_modules=[
           'chromaprint',
@@ -55,4 +54,4 @@ setup(name='pyacoustid',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3',
       ],
-)
+      )


### PR DESCRIPTION
The following small flake8 (style) issues are fixed:
* only a single space before inline comment
* class without CamelCase style name

Now the module is flake8 clean (for python2 and python3).