### PR TITLE
Close "Session" socket when finished

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -178,12 +178,12 @@ def _api_request(url, params):
         "Content-Type": "application/x-www-form-urlencoded"
     }
 
-    session = requests.Session()
-    session.mount('http://', CompressedHTTPAdapter())
-    try:
-        response = session.post(url, data=params, headers=headers)
-    except requests.exceptions.RequestException as exc:
-        raise WebServiceError("HTTP request failed: {0}".format(exc))
+    with requests.Session() as session:
+        session.mount('http://', CompressedHTTPAdapter())
+        try:
+            response = session.post(url, data=params, headers=headers)
+        except requests.exceptions.RequestException as exc:
+            raise WebServiceError("HTTP request failed: {0}".format(exc))
 
     try:
         return response.json()


### PR DESCRIPTION
By using just:
```python
session = requests.Session()
# stuff
try:
    return response.json()
except ValueError:
    raise WebServiceError("···")
```
the `Session` is not closed so there is a `STREAM` (`SocketKind.SOCK_STREAM`) opened until the Python application finishes.

By using the `with` statement, we ensure that even if an unhandled exception is thrown the socket will be always closed (see: [Advanced Usage - Session Objects](https://2.python-requests.org/en/master/user/advanced/#session-objects))