### PR TITLE
Fix the shared library load for Windows

### DIFF
--- a/chromaprint.py
+++ b/chromaprint.py
@@ -6,6 +6,7 @@
 
 import sys
 import ctypes
+import ctypes.util
 
 if sys.version_info[0] >= 3:
     BUFFER_TYPES = (memoryview, bytearray,)
@@ -31,9 +32,19 @@ def _guess_lib_name():
     return ('libchromaprint.so.1', 'libchromaprint.so.0')
 
 
+def _load_library(name):
+    if sys.platform == 'win32':
+        try:
+            return ctypes.cdll.LoadLibrary(ctypes.util.find_library(name))
+        except TypeError:
+            raise OSError()
+    else:
+        return ctypes.cdll.LoadLibrary(name)
+
+
 for name in _guess_lib_name():
     try:
-        _libchromaprint = ctypes.cdll.LoadLibrary(name)
+        _libchromaprint = _load_library(name)
         break
     except OSError:
         pass


### PR DESCRIPTION
Search for the chromaprint shared library on Windows using ctypes.util.find_library() and use the full path as argument for ctypes.cdll.LoadLibrary() instead of just the library name.
Solves #54: "couldn't find libchromaprint" error on Windows and Python 3.8.