### PR TITLE
Fixed issue with URL encoding

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -231,7 +231,10 @@ def fingerprint(samplerate, channels, pcmiter, maxlength=MAX_AUDIO_LENGTH):
 
 def lookup(apikey, fingerprint, duration, meta=DEFAULT_META, timeout=None):
     """Look up a fingerprint with the Acoustid Web service. Returns the
-    Python object reflecting the response JSON data.
+    Python object reflecting the response JSON data. To get more data back
+    ``meta`` can be a list of strings or a '+' or ' ' concatenated string of 
+    keywords. Those can be recordings, recordingids, releases, releaseids, 
+    releasegroups, releasegroupids, tracks, compress, usermeta, sources.
     """
     params = {
         'format': 'json',
@@ -347,7 +350,10 @@ def match(apikey, path, meta=DEFAULT_META, parse=True, force_fpcalc=False,
     small tuple of relevant information; otherwise, the full parsed JSON
     response is returned. Fingerprinting uses either the Chromaprint
     library or the fpcalc command-line tool; if ``force_fpcalc`` is
-    true, only the latter will be used.
+    true, only the latter will be used. To get more data back ``meta`` can be 
+    a list of strings or a '+' or ' ' concatenated string of keywords.
+    Those can be recordings, recordingids, releases, releaseids, releasegroups, 
+    releasegroupids, tracks, compress, usermeta, sources.
     """
     duration, fp = fingerprint_file(path, force_fpcalc=force_fpcalc)
     response = lookup(apikey, fp, duration, meta, timeout)

--- a/acoustid.py
+++ b/acoustid.py
@@ -35,10 +35,11 @@ import threading
 import time
 import gzip
 from io import BytesIO
+from urllib.parse import urlencode
 
 
 API_BASE_URL = 'http://api.acoustid.org/v2/'
-DEFAULT_META = 'recordings'
+DEFAULT_META = ['recordings']
 REQUEST_INTERVAL = 0.33  # 3 requests/second.
 MAX_AUDIO_LENGTH = 120  # Seconds.
 FPCALC_COMMAND = 'fpcalc'
@@ -179,10 +180,14 @@ def _api_request(url, params, timeout=None):
         "Content-Type": "application/x-www-form-urlencoded"
     }
 
+    params['meta'] = '+'.join(params['meta'])
+
     with requests.Session() as session:
         session.mount('http://', CompressedHTTPAdapter())
         try:
-            response = session.post(url, data=params, headers=headers,
+            response = session.post(url, 
+                                    data=urlencode(params, safe='+'),
+                                    headers=headers,
                                     timeout=timeout)
         except requests.exceptions.RequestException as exc:
             raise WebServiceError("HTTP request failed: {0}".format(exc))

--- a/acoustid.py
+++ b/acoustid.py
@@ -180,11 +180,11 @@ def _api_request(url, params, timeout=None):
         "Content-Type": "application/x-www-form-urlencoded"
     }
 
-    params['meta'] = '+'.join(params['meta'])
-
     with requests.Session() as session:
         session.mount('http://', CompressedHTTPAdapter())
         try:
+            if isinstance(params['meta'], list):
+                params['meta'] = ' '.join(str(item) for item in params['meta'])
             response = session.post(url, 
                                     data=urlencode(params, safe='+'),
                                     headers=headers,

--- a/acoustid.py
+++ b/acoustid.py
@@ -35,7 +35,6 @@ import threading
 import time
 import gzip
 from io import BytesIO
-from urllib.parse import urlencode
 
 
 API_BASE_URL = 'http://api.acoustid.org/v2/'
@@ -184,9 +183,9 @@ def _api_request(url, params, timeout=None):
         session.mount('http://', CompressedHTTPAdapter())
         try:
             if isinstance(params['meta'], list):
-                params['meta'] = ' '.join(str(item) for item in params['meta'])
-            response = session.post(url, 
-                                    data=urlencode(params, safe='+'),
+                params['meta'] = ' '.join(params['meta'])
+            response = session.post(url,
+                                    data=params,
                                     headers=headers,
                                     timeout=timeout)
         except requests.exceptions.RequestException as exc:
@@ -231,10 +230,10 @@ def fingerprint(samplerate, channels, pcmiter, maxlength=MAX_AUDIO_LENGTH):
 
 def lookup(apikey, fingerprint, duration, meta=DEFAULT_META, timeout=None):
     """Look up a fingerprint with the Acoustid Web service. Returns the
-    Python object reflecting the response JSON data. To get more data back
-    ``meta`` can be a list of strings or a '+' or ' ' concatenated string of 
-    keywords. Those can be recordings, recordingids, releases, releaseids, 
-    releasegroups, releasegroupids, tracks, compress, usermeta, sources.
+    Python object reflecting the response JSON data. To get more data
+    back, ``meta`` can be a list of keywords from this list: recordings,
+    recordingids, releases, releaseids, releasegroups, releasegroupids,
+    tracks, compress, usermeta, sources.
     """
     params = {
         'format': 'json',
@@ -350,10 +349,10 @@ def match(apikey, path, meta=DEFAULT_META, parse=True, force_fpcalc=False,
     small tuple of relevant information; otherwise, the full parsed JSON
     response is returned. Fingerprinting uses either the Chromaprint
     library or the fpcalc command-line tool; if ``force_fpcalc`` is
-    true, only the latter will be used. To get more data back ``meta`` can be 
-    a list of strings or a '+' or ' ' concatenated string of keywords.
-    Those can be recordings, recordingids, releases, releaseids, releasegroups, 
-    releasegroupids, tracks, compress, usermeta, sources.
+    true, only the latter will be used. To get more data back, ``meta``
+    can be a list of keywords from this list: recordings, recordingids,
+    releases, releaseids, releasegroups, releasegroupids, tracks,
+    compress, usermeta, sources.
     """
     duration, fp = fingerprint_file(path, force_fpcalc=force_fpcalc)
     response = lookup(apikey, fp, duration, meta, timeout)


### PR DESCRIPTION
The AcoustID Web Service offers the `meta` parameter to determine which
kind of information should be included in the response. This parameter
can consist of several keywords which are concatenated using `+`.
Unfortunately, this char is typically encoded as `%2B` by e.g. the
Requests Python library which is used in this project. This causes the
parameter to be ignored by the server. To prevent this, `urllib` is used
to preserve the `+`.
#63 