### PR TITLE
Fix #65: new crash when missing `meta` parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,10 @@ used when the Chromaprint library or fpcalc command-line tool cannot be found.
 Version History
 ---------------
 
+1.2.2
+  Fix a regression in the previous version that caused a `KeyError` crash when
+  calling `submit`.
+
 1.2.1
   The `meta` parameter to some API functions can now be a list (instead of
   just a single string).

--- a/acoustid.py
+++ b/acoustid.py
@@ -182,7 +182,7 @@ def _api_request(url, params, timeout=None):
     with requests.Session() as session:
         session.mount('http://', CompressedHTTPAdapter())
         try:
-            if isinstance(params['meta'], list):
+            if isinstance(params.get('meta'), list):
                 params['meta'] = ' '.join(params['meta'])
             response = session.post(url,
                                     data=params,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def _read(fn):
 
 
 setup(name='pyacoustid',
-      version='1.2.1',
+      version='1.2.2',
       description=('bindings for Chromaprint acoustic fingerprinting and the '
                    'Acoustid API'),
       author='Adrian Sampson',


### PR DESCRIPTION
Fixes #65: a new crash introduced in #64 when calling `_api_request` without a `meta` parameter, as in the `submit` function.
