### PR TITLE
decode_fingerprint bugfixes

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -382,7 +382,7 @@ def _match_fingerprints(a: List[int], b: List[int]) -> float:
             if biterror <= MAX_BIT_ERROR:
                 offset = i - j + bsize
                 counts[offset] += 1
-    topcount = counts.max()
+    topcount = max(counts)
     return topcount / min(asize, bsize)
 
 

--- a/acoustid.py
+++ b/acoustid.py
@@ -397,8 +397,8 @@ def compare_fingerprints(a, b) -> float:
         raise ModuleNotFoundError("function needs chromaprint")
 
     # decompress fingerprints
-    a = [int(x) for x in chromaprint.decode_fingerprint(a)[0]]
-    b = [int(x) for x in chromaprint.decode_fingerprint(b)[0]]
+    a = [int(x) for x in chromaprint.decode_fingerprint(a[1])[0]]
+    b = [int(x) for x in chromaprint.decode_fingerprint(b[1])[0]]
     return _match_fingerprints(a, b)
 
 


### PR DESCRIPTION
Here are some bug fixes for decode_fingerprint calulation which, at this moment, raises exception:

- `chromaprint.decode_fingerprint` function raises TypeError, in fact it needs a fingerprint as the parameter, in the file variables `a` and `b` are tuples (duration, fingerprint) since they are output of `fingerprint_file` function.
- `list.max` raised exception saying that list has no attribute max, in fact the correct function is `max(list)`

New code is tested both on Windows 11 and Ubuntu 20.