### PR TITLE
Windows import library fix

### DIFF
--- a/chromaprint.py
+++ b/chromaprint.py
@@ -25,7 +25,7 @@ def _guess_lib_name():
     if sys.platform == 'darwin':
         return ('libchromaprint.1.dylib', 'libchromaprint.0.dylib')
     elif sys.platform == 'win32':
-        return ('chromaprint.dll', 'libchromaprint.dll')
+        return ('', 'libchromaprint.dll')
     elif sys.platform == 'cygwin':
         return ('libchromaprint.dll.a', 'cygchromaprint-1.dll',
                 'cygchromaprint-0.dll')
@@ -44,7 +44,10 @@ def _load_library(name):
             return None
 
     try:
-        return ctypes.cdll.LoadLibrary(name)
+        if sys.platform == 'win32':
+            return ctypes.WinDLL(name, winmode=0)
+        else:
+            return ctypes.cdll.LoadLibrary(name)
     except OSError:
         return None
 


### PR DESCRIPTION
This code is tested on my Windows 11 machine.

Only `libchromaprint.dll` is created by chromaprint's build, and it contains all the used functions, so I removed `chromaprint.dll`.

Also library load doesn't work without `winmode=0` for some reason.