### PR TITLE
Port PR88 to 1.3.1

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -17,6 +17,10 @@ import errno
 import json
 import os
 
+import sys
+if sys.byteorder == 'big':
+    import struct
+
 import requests
 
 try:
@@ -207,6 +211,17 @@ def _api_request(url, params, timeout=None):
 
 # Main API.
 
+def byteswap(s):
+    """Swaps the endianness of the bytestring s, which must be an array
+    of shorts (16-bit signed integers).
+    """
+    assert len(s) % 2 == 0
+    parts = []
+    for i in range(0, len(s), 2):
+        chunk = s[i:i + 2]
+        newchunk = struct.pack('>h', *struct.unpack('<h', chunk))
+        parts.append(newchunk)
+    return b''.join(parts)
 
 def fingerprint(samplerate, channels, pcmiter, maxlength=MAX_AUDIO_LENGTH):
     """Fingerprint audio data given its sample rate and number of
@@ -228,6 +243,11 @@ def fingerprint(samplerate, channels, pcmiter, maxlength=MAX_AUDIO_LENGTH):
             except StopIteration:
                 # No more data
                 break
+
+            # On big-endian machines, audioread reads in s16le format
+            # which needs to be byteswapped for chromaprint
+            if sys.byteorder == 'big':
+                block = byteswap(block)
 
             # Calculate remaining samples needed
             remaining = endposition - position


### PR DESCRIPTION
https://github.com/beetbox/pyacoustid/pull/88 by @pranavkaruvally still stands as pointed out in the PR by @sandrotosi in
https://github.com/beetbox/pyacoustid/pull/88#issuecomment-4249512294

Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1093700

Tested on a qemu s390x machine using the debian autopkgtest script fingerprint-calculation, which uses import acoustid; print(acoustid.fingerprint_file('$EXAMPLE_FILE')[1].decode()) as explained in PR88.

```bash
debian@debian:~/src/pyacoustid$ dpkg --print-architecture
s390x
debian@debian:~/src/pyacoustid$ git clean -fdx . && git reset --hard  
HEAD is now at fc66cab Refresh PR88.patch
debian@debian:~/src/pyacoustid$ bash ./debian/tests/fingerprint-calculation 
/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga: OK
Not all generated fingerprints match the expected fingerprint for example file (/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga):
  expected fingerprint  : AQAAHImSSEqSZFGiCLjxw9bxw8V9fMeJ-zhs4YeL48eJzzi8CSfM4DieAfcB5ZQ0QkgBjRLOCIegIeY5c5QA
  calculated via python3: AQAAHEmiJEqUJUnCCMd72Cf0KMSfoTzECa2SZbg5nIOn42EIPcoM-UIDxsp2XEyO9ygat9Cz5bgEDUwq4tICndAPMYwRjEBElBLOGCGQUN5YZAA
debian@debian:~/src/pyacoustid$ patch -p1 < debian/patches/PR88.patch 
patching file acoustid.py
debian@debian:~/src/pyacoustid$ bash ./debian/tests/fingerprint-calculation 
/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga: OK
debian@debian:~/src/pyacoustid$ 
```